### PR TITLE
fix(analytics): Testing variants of env vars

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_DEMO="potatos are great"
+NEXT_PUBLIC_MYVALUE="potatos are super great"

--- a/next.config.js
+++ b/next.config.js
@@ -48,6 +48,6 @@ module.exports = withMdx({
     env: {
         NEXT_PUBLIC_FATHOM_SITE_ID: process.env.NEXT_PUBLIC_FATHOM_SITE_ID,
         NEXT_PUBLIC_FATHOM_URL: process.env.NEXT_PUBLIC_FATHOM_URL,
-        NEXT_PUBLIC_DEMO: process.env.NEXT_PUBLIC_DEMO,
+        NEXT_PUBLIC_DEMO: "STATIC"
     },
 })

--- a/next.config.js
+++ b/next.config.js
@@ -46,7 +46,7 @@ module.exports = withMdx({
     },
     pageExtensions: ['js', 'jsx', 'mdx', 'tsx', 'ts'],
     env: {
-        FATHOM_SITE_ID: process.env.FATHOM_SITE_ID,
-        FATHOM_URL: process.env.FATHOM_URL
+        FATHOM_SITE_ID: process.env.NEXT_PUBLIC_FATHOM_SITE_ID,
+        FATHOM_URL: process.env.NEXT_PUBLIC_FATHOM_URL
     },
 })

--- a/next.config.js
+++ b/next.config.js
@@ -46,8 +46,8 @@ module.exports = withMdx({
     },
     pageExtensions: ['js', 'jsx', 'mdx', 'tsx', 'ts'],
     env: {
-        NEXT_PUBLIC_FATHOM_SITE_ID: process.env.NEXT_PUBLIC_FATHOM_SITE_ID,
-        NEXT_PUBLIC_FATHOM_URL: process.env.NEXT_PUBLIC_FATHOM_URL,
-        NEXT_PUBLIC_DEMO: "STATIC"
+        NEXT_PUBLIC_ANALYTICS_SITE_ID: process.env.FATHOM_SITE_ID,
+        NEXT_PUBLIC_ANALYTICS_URL: process.env.FATHOM_URL,
+        NEXT_PUBLIC_DEMO: process.env.DEMO_VALUE,
     },
 })

--- a/next.config.js
+++ b/next.config.js
@@ -46,7 +46,7 @@ module.exports = withMdx({
     },
     pageExtensions: ['js', 'jsx', 'mdx', 'tsx', 'ts'],
     env: {
-        FATHOM_SITE_ID: process.env.NEXT_PUBLIC_FATHOM_SITE_ID,
-        FATHOM_URL: process.env.NEXT_PUBLIC_FATHOM_URL
+        NEXT_PUBLIC_FATHOM_SITE_ID: process.env.NEXT_PUBLIC_FATHOM_SITE_ID,
+        NEXT_PUBLIC_FATHOM_URL: process.env.NEXT_PUBLIC_FATHOM_URL
     },
 })

--- a/next.config.js
+++ b/next.config.js
@@ -47,6 +47,7 @@ module.exports = withMdx({
     pageExtensions: ['js', 'jsx', 'mdx', 'tsx', 'ts'],
     env: {
         NEXT_PUBLIC_FATHOM_SITE_ID: process.env.NEXT_PUBLIC_FATHOM_SITE_ID,
-        NEXT_PUBLIC_FATHOM_URL: process.env.NEXT_PUBLIC_FATHOM_URL
+        NEXT_PUBLIC_FATHOM_URL: process.env.NEXT_PUBLIC_FATHOM_URL,
+        NEXT_PUBLIC_DEMO: process.env.NEXT_PUBLIC_DEMO,
     },
 })

--- a/pages/100days/day02.mdx
+++ b/pages/100days/day02.mdx
@@ -1,0 +1,56 @@
+import VerticallyCentered from 'layouts/verticallyCentered'
+
+export default VerticallyCentered
+
+export const frontMatter = {
+    title: 'Analytics and env variables...',
+}
+
+<h1>{frontMatter.title}</h1>
+
+Today I worked on a couple of updates to the base `_app.jsx` template. There's
+not much on the page right now: almost nothing for a visual template outside of
+vertically centering and applying a max-width to the content.
+
+## Color Theme
+
+However, I was able to update the colors to use a base theme that is more
+analagous for now. (I generated the theme at coolors,
+[available here](https://coolors.co/cad5a6-a4b374-8db01a-535745-666665), then
+made minor adjustments to individual shades where necessary to improve color
+contrast.)
+
+## Dark Mode
+
+I also applied a simple media query to enable a dark mode variant. (Even if we
+don't have a toggle on page yet, at least the page will show up darker for folks
+that use a dark system or themes.) The dark mode version will use dark hues and
+automatically thin the san-serif font a little.
+
+I also fleshed out the [`100Days`](./100days) page for tracking this project
+progress. Updated some of the colors used along with a very rudimentary
+dark-mode variation. Also made some tweaks so my tracking code works properly.
+
+## Troubleshooting...
+
+I did run into some difficulty getting the environment variables that I feed
+into my client side analytics solution to map correctly. While the server side
+components have access to env values easily enough, they only end up being
+passed to the client side code on vercel if you make sure to prefix them
+correctly.
+
+I shifted values around a couple of times and finally found what works. My
+testing consisted of various commits to a feature branch and deployed
+automatically on vercel. From there I was able to make updates incrementally and
+verify whether or not the values made it to the browser.
+
+-   You can set whatever you want for the root environment variable KEYS (the
+    values you'd set with real environment variables or passed from the
+    environment config from vercel)
+-   In `next.config.js` your environment variables are mapped.
+-   You must use `.env` keys here with `NEXT_PUBLIC_` prefixed to make them
+    actually available to scripts.
+-   Your scripts should generally refer to `process.env.NEXT_PUBLIC_X` directly.
+    I def couldn't `console.log` the value of `process.env` directly, it was
+    always undefined, so I suspect there is a loader somewhere that is
+    transforming those environment values for runtime somehow...

--- a/pages/100days/index.mdx
+++ b/pages/100days/index.mdx
@@ -4,6 +4,7 @@ export default VerticallyCentered
 
 export const frontMatter = {
     title: '100 Days of Projects',
+    date: '2020-08-17',
 }
 
 # 100 Days of Projects
@@ -44,10 +45,7 @@ homepage:
 -   Day 01: Took my experimental mdx/next site, cloned it and put in _just
     enough_ content to have something to deploy. Got things up and running on my
     domain (`jem.dev`).
--   Day 02: Fleshed out the `100Days` page for tracking this project progress.
-    Updated some of the colors used along with a very rudimentary dark-mode
-    variation. Also made some tweaks so my tracking code works properly.
-
+-   [Day 02](100days/day02): Analytics things...
 ---
 
 [return home](/)

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -32,10 +32,9 @@ const Application = ({ Component, pageProps }) => {
 
     const FATHOM_SITE_ID = process.env.NEXT_PUBLIC_FATHOM_SITE_ID
     const FATHOM_URL = process.env.NEXT_PUBLIC_FATHOM_URL
-    const PUBLIC_DEMO = process.env.NEXT_PUBLIC_DEMO
 
     useEffect(() => {
-        console.log("We are initing analtyics, but don't have values?", { FATHOM_SITE_ID, FATHOM_URL , PUBLIC_DEMO})
+        console.log(`We are initing analtyics, but don't have values? ${process.env.NEXT_PUBLIC_DEMO}`)
         // Initialize Fathom when the app loads
         Fathom.load(FATHOM_SITE_ID, {
             url: FATHOM_URL,

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -35,7 +35,6 @@ const Application = ({ Component, pageProps }) => {
 
     useEffect(() => {
         // Initialize Fathom when the app loads
-        console.log("Okay, we're running with", { FATHOM_SITE_ID, FATHOM_URL })
         Fathom.load(FATHOM_SITE_ID, {
             url: FATHOM_URL,
         })

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -30,8 +30,8 @@ const components = {
 const Application = ({ Component, pageProps }) => {
     const router = useRouter()
 
-    const FATHOM_SITE_ID = process.env.FATHOM_SITE_ID
-    const FATHOM_URL = process.env.FATHOM_URL
+    const FATHOM_SITE_ID = process.env.NEXT_PUBLIC_FATHOM_SITE_ID
+    const FATHOM_URL = process.env.NEXT_PUBLIC_FATHOM_URL
 
     useEffect(() => {
         console.log("We are initing analtyics, but don't have values?", { FATHOM_SITE_ID, FATHOM_URL })

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -34,6 +34,7 @@ const Application = ({ Component, pageProps }) => {
     const FATHOM_URL = process.env.FATHOM_URL
 
     useEffect(() => {
+        console.log("We are initing analtyics, but don't have values?", { FATHOM_SITE_ID, FATHOM_URL })
         // Initialize Fathom when the app loads
         Fathom.load(FATHOM_SITE_ID, {
             url: FATHOM_URL,

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -35,6 +35,7 @@ const Application = ({ Component, pageProps }) => {
 
     useEffect(() => {
         // Initialize Fathom when the app loads
+        console.log("Okay, we're running with", { FATHOM_SITE_ID, FATHOM_URL })
         Fathom.load(FATHOM_SITE_ID, {
             url: FATHOM_URL,
         })

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -32,9 +32,10 @@ const Application = ({ Component, pageProps }) => {
 
     const FATHOM_SITE_ID = process.env.NEXT_PUBLIC_FATHOM_SITE_ID
     const FATHOM_URL = process.env.NEXT_PUBLIC_FATHOM_URL
+    const PUBLIC_DEMO = process.env.NEXT_PUBLIC_DEMO
 
     useEffect(() => {
-        console.log("We are initing analtyics, but don't have values?", { FATHOM_SITE_ID, FATHOM_URL })
+        console.log("We are initing analtyics, but don't have values?", { FATHOM_SITE_ID, FATHOM_URL , PUBLIC_DEMO})
         // Initialize Fathom when the app loads
         Fathom.load(FATHOM_SITE_ID, {
             url: FATHOM_URL,

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -10,11 +10,11 @@ import React from 'react'
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { MDXProvider } from '@mdx-js/react'
-import process from 'process'
 import * as Fathom from 'fathom-client'
 
 import Link from 'next/link'
 
+const PUBLIC = process.env.NEXT_PUBLIC_DEMO
 
 // Some codeblock styles for now...
 import 'highlight.js/styles/shades-of-purple.css'
@@ -30,11 +30,10 @@ const components = {
 const Application = ({ Component, pageProps }) => {
     const router = useRouter()
 
-    const FATHOM_SITE_ID = process.env.NEXT_PUBLIC_FATHOM_SITE_ID
-    const FATHOM_URL = process.env.NEXT_PUBLIC_FATHOM_URL
+    const FATHOM_SITE_ID = process.env.NEXT_PUBLIC_ANALYTICS_SITE_ID
+    const FATHOM_URL = process.env.NEXT_PUBLIC_ANALYTICS_URL
 
     useEffect(() => {
-        console.log(`We are initing analtyics, but don't have values? ${process.env.NEXT_PUBLIC_DEMO}`)
         // Initialize Fathom when the app loads
         Fathom.load(FATHOM_SITE_ID, {
             url: FATHOM_URL,


### PR DESCRIPTION
Environment variables are defined in the next.config.js, mapped
initially from env values. As far as documentation is concerned, we
should be showing some of these values in our console?