### PR TITLE
feat(day10): Day10 post, whois, a placeholder

### DIFF
--- a/components/page/HeadSidebar.tsx
+++ b/components/page/HeadSidebar.tsx
@@ -25,6 +25,7 @@ interface MenuMap {
  */
 const menu: MenuMap = {
     'Home': '/',
+    '/whois @jemjam': '/whois',
     '#100DaysOfProjects': '/100days',
 }
 

--- a/layouts/default.tsx
+++ b/layouts/default.tsx
@@ -23,12 +23,12 @@ const DefaultLayout: FunctionComponent<DefaultLayoutProp> = ({
                 {frontMatter?.title && <h1>{pageTitle}</h1>}
             </header>
             <div className="contentRegion">{children}</div>
-            <footer className="contentFooter">
-                <hr/>
-                {frontMatter?.date && (
+            {frontMatter?.date && (
+                <footer className="contentFooter">
+                    <hr />
                     <span>posted: {frontMatter?.date ?? '-unknown-'}</span>
-                )}
-            </footer>
+                </footer>
+            )}
         </>
     )
 }

--- a/next.config.js
+++ b/next.config.js
@@ -5,24 +5,28 @@ const highlight = require('remark-highlight.js')
 const withMdxEnhanced = require('next-mdx-enhanced')
 
 // Standard (non-enhanced) mdx approach...
-// const withMDX = require('@next/mdx')({
-//     extension: /\.mdx?$/,
-// })
-
-// For now we're using enchance layouts tho...
-const withMdx = withMdxEnhanced({
-    layoutPath: 'layouts',
-    // defaultLayout: true,
-    fileExtensions: ['mdx'],
-    remarkPlugins: [images, emoji, highlight],
-    rehypePlugins: [],
-    extendFrontMatter: {
-        process: (mdxContent, frontMatter) => {},
-        phase: 'prebuild|loader|both',
-    },
+const withMDX = require('@next/mdx')({
+    extension: /\.mdx?$/,
+    options: {
+        remarkPlugins: [images, emoji, highlight],
+        rehypePlugins: [],
+    }
 })
 
-module.exports = withMdx({
+// For now we're using enchance layouts tho...
+// const withMdx = withMdxEnhanced({
+//     layoutPath: 'layouts',
+//     // defaultLayout: true,
+//     fileExtensions: ['mdx'],
+//     remarkPlugins: [images, emoji, highlight],
+//     rehypePlugins: [],
+//     extendFrontMatter: {
+//         process: (mdxContent, frontMatter) => {},
+//         phase: 'prebuild|loader|both',
+//     },
+// })
+
+module.exports = withMDX({
     webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
         // Note: we provide webpack above so you should not `require` it
         // Perform customizations to webpack config

--- a/pages/100days/day10.mdx
+++ b/pages/100days/day10.mdx
@@ -1,0 +1,68 @@
+import Layout from 'layouts/default'
+
+export default Layout
+
+export const frontMatter = {
+    title: 'Day 10: Learning in the open...',
+    desc: '',
+    date: '2020-08-25',
+    day: 10,
+}
+
+[#100DaysOfProjects](./)
+
+Have I mentioned yet that I kind of find learning in the open disingenuous.
+There's just something about the fact that we have to essentially _hustle_ our
+way through demonstrating our coding proficiency that feels... not great.
+
+It's not that I take issue with learning in any form. It's the "in the open"
+that seems problematic. On some level, I think I was raised to learn quietly and
+individually first. You test and prove your ideas privately before you put them
+out into the world. It feels faux pas to share content (to become a casual
+authority on a topic) when you're still just figuring things out.
+
+I think my hesitation also comes from worrying too much about taking up space. I
+think our culture tends to reward folks who are willing to "take up space". In
+advertising, the people who take up the most space often end up making the most
+sales, right? And we're taught that "fortune favours the bold". "The squeaky
+wheel gets the grease". "It's better to ask forgiveness than beg permission".
+
+Unfortunately, in my experience, the side effect of always filling a lot of
+space is you don't leave much room for others to join you equitably. Turns out
+certain folks "boldness" may often be antithetical to actual inclusivity.
+
+But of course, I'm generalizing here. YMMV, depending on the organization,
+depending on your involvement and interest in the topic. I don't mean to shame
+anyone who is sharing their process as they learn to stack their bricks _in the
+open_.
+
+I just have a lot of doubt about whether I want to **add to all of that noise**.
+On some level I do believe that every individual has a unique perspective to
+share, I'm just not quite confident I've found mine yet.
+
+...
+
+I'll think about this a bit more and try to sit with this before I rag on it too
+much more. If you're someone learning in the open... or if you're someone who
+values following along with people in the open... let me know what you think on
+twitter (@itsjemjam), I'm truly curious.
+
+IF it helps: I don't feel too bad about posting day over day for this `100Days`
+thing (etc). I've learned it's useful to put these out there as an exercise, so
+it's not quite the same as "learning in the open"? Or is it..? (Maybe my goal is
+just to do it enough that I don't put up these blockers in the first place... but clearly I'm still conflicted...)
+
+## Today's Clippings 🍃
+
+-   OMG looking back at the last couple of days, soo many typos. Fixed up one or
+    two that I was able to find (thanks to
+    [@mnmlsm0](https://twitter.com/mnmlsm0) on twitter for
+    [pointing out an obvious one](https://twitter.com/mnmlsm0/status/1295746832170188801)).
+    Will maybe look at a spell checker long term...
+-   Added a first draft of [`/whois`](/whois): I figure if folks are going to
+    look at my dumb progress every day they might as well have a clear spot to
+    find out about me. Linked in header (sidebar).
+-   Post (above) about my hesitation on learning in the open
+-   Added a placeholder page where I'll post details about my
+    #InfoProductChallenge workshop I've been cooking up. Details incoming
+    tomorrow...

--- a/pages/100days/index.mdx
+++ b/pages/100days/index.mdx
@@ -1,10 +1,12 @@
+import Layout from 'layouts/default'
+
+export default Layout
 
 export const frontMatter = {
     title: '100 Days of Projects',
+    desc: '',
     date: '2020-08-17',
 }
-
-# 100 Days of Projects
 
 I've decided to start the 100days challenge, if ONLY because I've thought about
 building something for awhile and always get caught up trying to plan too much.
@@ -48,6 +50,7 @@ homepage:
 -   [Day 07](100days/day07): 2020-08-22
 -   [Day 08](100days/day08): 2020-08-23
 -   [Day 09](100days/day09): 2020-08-24
+-   [Day 10](100days/day10): 2020-08-25
 
 ---
 

--- a/pages/collab-class/index.mdx
+++ b/pages/collab-class/index.mdx
@@ -1,0 +1,11 @@
+import Layout from 'layouts/default'
+
+export default Layout
+
+export const frontMatter = {
+    title: 'Collab Class vol 1',
+    desc: "Let's talk about how to do remote!",
+    date: '2020-08-17',
+}
+
+This page is a work in progress. Did you find it? There's no content here yet but I'll link to it when I have some. (Probably by tomorrow...)

--- a/pages/digital-garden.mdx
+++ b/pages/digital-garden.mdx
@@ -8,7 +8,7 @@ export const frontMatter = {
 Hi, my name is Jem, and I'm working on a digital garden.
 
 A digital garden is kind of like a personal blog or website, but it's meant to
-grow more ogranically. The core idea (as I understand it) is you post early and
+grow more organically. The core idea (as I understand it) is you post early and
 often, and iterate on your content continually. Over time the good stuff grows,
 and you weed out the junk.
 

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,2 +1,2 @@
 
-# [barely sprouted](/digital-garden)
+# [jem's digital garden](/digital-garden)

--- a/pages/whois/index.mdx
+++ b/pages/whois/index.mdx
@@ -1,0 +1,29 @@
+import Layout from 'layouts/default'
+
+export default Layout
+
+export const frontMatter = {
+    title: 'Who is Jem?',
+    desc: 'A little bit about this fella.',
+    created: '2020-08-25',
+    updated: '2020-08-25',
+}
+
+This is a page where I might talk about me a little bit. You're on my domain on
+a page titled "whois": what did you expect?
+
+## Jem is a web developer based in Victoria BC
+
+I've been working on the web professionally since as early as 2008, but I've
+been playing with building websites and web stuff since as early as 1997 (a
+young thirteen year old on the early internet). Over the last six years I've
+taken on roles with various tech companies, from agency life, to a small email
+startup, and on now to a "digital availability" SaaS platform.
+
+In my spare time I like to:
+
+-   Do a little bit of OSS: Lately i'm trying to help out with some of the
+    nodejs.dev redesign.
+-   Work in the open? LOL nope: but I'm def trying.
+-   Build web stuff and share knowledge: a continual journey and work in
+    progress


### PR DESCRIPTION
In the next couple of days I hope to get a placeholder page online that
can share some of the content I'm building for the CollabClass.

But in the meantime, for tonight I'm just adding a day10 post and a
couple of misc typo updates.

Also updated the core next.config.js to only use core mdx module, not
the mdx-enhanced module